### PR TITLE
Add other kind of onekos (Tora, Dog)

### DIFF
--- a/src/plugins/oneko/index.ts
+++ b/src/plugins/oneko/index.ts
@@ -19,6 +19,42 @@
 import { definePluginSettings, migratePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
+let script: string | null = null;
+
+
+
+const enum Follower {
+    Oneko,
+    Tora,
+    Dog,
+}
+
+function getFollowerMap(who: Follower): string {
+    switch (who) {
+        case Follower.Oneko:
+            return "https://i.imgur.com/Va6wavs.png";
+        case Follower.Tora:
+            return "https://i.imgur.com/Xvi7xiX.png";
+        case Follower.Dog:
+            return "https://i.imgur.com/RXjBjN2.png";
+        default:
+            return "https://raw.githubusercontent.com/adryd325/oneko.js/14bab15a755d0e35cd4ae19c931d96d306f99f42/oneko.gif";
+    }
+}
+
+function applySettingsChangeAndExec() {
+    if (!Vencord.Plugins.isPluginEnabled("Oneko")) return;
+    if (!script) {
+        console.error("[oneko] script is not loaded");
+        return;
+    }
+
+    document.getElementById("oneko")?.remove();
+    (0, eval)(script.replace("./oneko.gif", getFollowerMap(settings.store.follower))
+        .replace("const nekoSpeed = 10;", `const nekoSpeed = ${settings.store.speed};`)
+        .replace("(isReducedMotion)", "(false)")
+    );
+}
 
 
 const settings = definePluginSettings({
@@ -30,19 +66,17 @@ const settings = definePluginSettings({
             if (value && value < 0) return "The number must be bigger than 0";
             return true;
         },
-        onChange: () => {
-            // note: cant call the start() function from here. so i just copy pasted it (This was pointed out in the last commit i made. So this is to just clear stuff up for any future devs that work on this :D )
-            if (Vencord.Plugins.isPluginEnabled("Oneko")) {
-                document.getElementById("oneko")?.remove();
-                fetch("https://raw.githubusercontent.com/adryd325/oneko.js/c4ee66353b11a44e4a5b7e914a81f8d33111555e/oneko.js")
-                    .then(x => x.text())
-                    .then(s => s.replace("const nekoSpeed = 10;", `const nekoSpeed = ${settings.store.speed};`))
-                    .then(s => s.replace("./oneko.gif", "https://raw.githubusercontent.com/adryd325/oneko.js/c4ee66353b11a44e4a5b7e914a81f8d33111555e/oneko.gif")
-                        .replace("(isReducedMotion)", "(false)"))
-                    .then(eval);
-            }
-            return;
-        }
+        onChange: applySettingsChangeAndExec
+    },
+    follower: {
+        type: OptionType.SELECT,
+        description: "Choose which neko follows mouse",
+        options: [
+            { label: "Oneko", value: Follower.Oneko, default: true },
+            { label: "Tora", value: Follower.Tora },
+            { label: "Dog", value: Follower.Dog },
+        ],
+        onChange: applySettingsChangeAndExec
     }
 });
 
@@ -57,10 +91,8 @@ export default definePlugin({
     start() {
         fetch("https://raw.githubusercontent.com/adryd325/oneko.js/c4ee66353b11a44e4a5b7e914a81f8d33111555e/oneko.js")
             .then(x => x.text())
-            .then(s => s.replace("const nekoSpeed = 10;", `const nekoSpeed = ${settings.store.speed};`))
-            .then(s => s.replace("./oneko.gif", "https://raw.githubusercontent.com/adryd325/oneko.js/c4ee66353b11a44e4a5b7e914a81f8d33111555e/oneko.gif")
-                .replace("(isReducedMotion)", "(false)"))
-            .then(eval);
+            .then(sc => script = sc)
+            .then(_ => applySettingsChangeAndExec());
     },
 
     stop() {


### PR DESCRIPTION
- Add a setting with a dropdown list of usable followers (currently Oneko (the original), Tora (a cat), and Dog (...))
- This selects different sprites generated from the original oneko program (I can release the tool that assembles the images too) (the images have then been edited manually so that i.e. the Zzzs are more visible) (the images were uploaded to imgur but that can be changed)
- The JS script is loaded on plugin startup, then is cached and reused when changing settings (including the speed setting)

- I tried to commit this to vencord but vendicated said no :c